### PR TITLE
docs: canonize release model (deploy ≠ merge) in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Project: wilkieandco
+
+## Release model (deploy ≠ merge)
+
+- `main` is integration: merging a PR to `main` produces a **preview deploy only**. It never touches production.
+- `production` is the release branch: the Vercel Production Branch points to it. Production deploys **only** when `main` is promoted (merge / fast-forward `main` → `production`).
+- Promotion is an explicit, human-gated action. **Never** push, merge, or open auto-merging PRs targeting `production`.
+- Database migration safety is assessed at promote time, not merge time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Adds the canonical release model to repo agent instructions (AGENTS.md, with CLAUDE.md import):

- merge to `main` = preview deploy only
- prod release = explicit human-gated promote (`main` → `production`)
- never target `production` autonomously
- migration safety checked at promote time

Context: Vercel Production Branch cutover wave 2, 2026-07-17 (following the 7-project wave 1, evidence on Paperclip KYL-1041). `production` pinned at current prod SHA; main==prod at flip time so zero deploy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)